### PR TITLE
added build directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.pro.user
 deployAppstore.sh
+/build/


### PR DESCRIPTION
This is not needed when using Qt Creator but the documentation states to use a manually created build directory and therefore I think it would be good to add it to ignore.