### PR TITLE
added operator as CloudLog expects that to set the station operator

### DIFF
--- a/src/adiftools.cpp
+++ b/src/adiftools.cpp
@@ -117,6 +117,7 @@ QString adifTools::assemble(QString call,
     QString str = QString("") +
                   "<call:"             + QString::number(call.size())     + ">" + call +
                   "<station_callsign:" + QString::number(ownCall.size())  + ">" + ownCall +
+                  "<operator:"         + QString::number(ownCall.size())  + ">" + ownCall +
                   "<band:"             + QString::number(band.size())     + ">" + band +
                   "<mode:"             + QString::number(mode.size())     + ">" + mode +
                   "<freq:"             + QString::number(freqN.size())    + ">" + freqN +


### PR DESCRIPTION
This is related to #58 

Added the OPERATOR to the adif file as cloud log expects that (not using the station_callsign) to set the station operator in the QSO.