### PR TITLE
Remove unused parameter country

### DIFF
--- a/src/repeatermodel.cpp
+++ b/src/repeatermodel.cpp
@@ -103,11 +103,11 @@ void rbManager::positionDecoded()
         coord = loc.coordinate();
         calculateMaidenhead(coord.latitude(),coord.longitude());
         qDebug() << "Location:" << country << coord.latitude() << coord.longitude() << locator;
-        getRepeaters(country);
+        getRepeaters();
     }
 }
 
-void rbManager::getRepeaters(QString country)
+void rbManager::getRepeaters()
 {
     //QString url = "https://www.repeaterbook.com/api/exportROW.php?country="+country;
     QString url = "https://hearham.com/api/repeaters/v1";

--- a/src/repeatermodel.h
+++ b/src/repeatermodel.h
@@ -70,7 +70,7 @@ private:
     QString locator;
     QGeoCoordinate coord;
     bool initialized;
-    void getRepeaters(QString country);
+    void getRepeaters();
     bool filter(double rLat, double rLon, double radius);
     double distance(double rLat, double rLon);
     void calculateMaidenhead(double lat, double lon);


### PR DESCRIPTION
Fixes another compiler warning:

```
../src/repeatermodel.cpp: In member function ‘void rbManager::getRepeaters(QString)’:
../src/repeatermodel.cpp:110:38: warning: unused parameter ‘country’ [-Wunused-parameter]
  110 | void rbManager::getRepeaters(QString country)
      |                              ~~~~~~~~^~~~~~~
```