### PR TITLE
Drop unused Qt Location dependency

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           version: '6.6.*'
           setup-python: false
-          modules: 'qtlocation qtpositioning'
+          modules: 'qtpositioning'
       - name: build-dor
         run: mkdir build
       - name: qmake

--- a/CloudLogOffline.pro
+++ b/CloudLogOffline.pro
@@ -4,7 +4,6 @@ QT += svg
 QT += xml
 QT += gui-private
 QT += positioning
-QT += location
 QT += widgets
 QT += core
 

--- a/src/repeatermodel.h
+++ b/src/repeatermodel.h
@@ -4,9 +4,6 @@
 #include <QGeoCoordinate>
 #include <QGeoPositionInfoSource>
 #include <QDebug>
-#include <QGeoCodingManager>
-#include <QGeoServiceProvider>
-#include <QGeoAddress>
 #include <QGeoLocation>
 #include <QJsonDocument>
 #include <QJsonObject>


### PR DESCRIPTION
AFAICS only Qt Positioning features are used at the moment.
(Qt Location is for "mapping and navigation".)