### PR TITLE
Reliable translation switching for PageDrawer

### DIFF
--- a/qml/DrawerItem.qml
+++ b/qml/DrawerItem.qml
@@ -44,14 +44,6 @@ ItemDelegate {
         return ""
     }
 
-    // Returns the title for the drawer item
-    function itemText (index) {
-        if (typeof (model.get (index).pageTitle) !== "undefined")
-            return model.get (index).pageTitle
-
-        return ""
-    }
-
     // Decide if we should highlight the item
     highlighted: ListView.isCurrentItem ? !isLink (index) : false
 
@@ -76,7 +68,7 @@ ItemDelegate {
         Label {
             opacity: 0.87
             font.pixelSize: 14
-            text: itemText (index)
+            text: pageTitle === undefined ? "" : pageTitle
             font.weight: Font.Medium
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter

--- a/qt5/qml/DrawerItem.qml
+++ b/qt5/qml/DrawerItem.qml
@@ -44,14 +44,6 @@ ItemDelegate {
         return ""
     }
 
-    // Returns the title for the drawer item
-    function itemText (index) {
-        if (typeof (model.get (index).pageTitle) !== "undefined")
-            return model.get (index).pageTitle
-
-        return ""
-    }
-
     // Decide if we should highlight the item
     highlighted: ListView.isCurrentItem ? !isLink (index) : false
 
@@ -76,7 +68,7 @@ ItemDelegate {
         Label {
             opacity: 0.87
             font.pixelSize: 14
-            text: itemText (index)
+            text: pageTitle === undefined ? "" : pageTitle
             font.weight: Font.Medium
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter


### PR DESCRIPTION
Translate the UI, not the list model.

Without this change, some menu items immediately followed the language setting but others didn't, on Linux desktop, Qt 6.6.1.

This is the suggested pattern in https://doc.qt.io/qt-6/i18n-source-translation.html#mark-translatable-data-text-strings. 
However, I could not make the proposed `qsTrNoOp` work, and `qsTr` is used in a different (translation) context, so the desired context has to be handled explicitly in the `ItemDelegate`