### PR TITLE
Refactor maidenhead code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(LibCloudLogOffline STATIC
     src/csvtools.cpp
     src/dbmanager.cpp
     src/logtools.cpp
+    src/maidenhead.cpp
     src/migrationmanager.cpp
     src/qrzmanager.cpp
     src/qsomodel.cpp

--- a/CloudLogOffline.pro
+++ b/CloudLogOffline.pro
@@ -29,6 +29,7 @@ SOURCES += src/cloudlogmanager.cpp
 SOURCES += src/csvtools.cpp
 SOURCES += src/dbmanager.cpp
 SOURCES += src/logtools.cpp
+SOURCES += src/maidenhead.cpp
 SOURCES += src/main.cpp
 SOURCES += src/migrationmanager.cpp
 SOURCES += src/qrzmanager.cpp

--- a/src/maidenhead.cpp
+++ b/src/maidenhead.cpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "maidenhead.h"
+
+#include <QGeoCoordinate>
+#include <QString>
+
+namespace maidenhead {
+
+QString fromLatLon(const QGeoCoordinate& coord)
+{
+    return fromLatLon(coord.latitude(), coord.longitude());
+}
+
+QString fromLatLon(double lat, double lon)
+{
+    static const QString alphabet = "ABCDEFGHIJKLMNOPQRSTUVWX";
+    static const QString numbers = "0123456789";
+
+    lat = qBound(0.0, lat + 90.0, 180.0);
+    lon = qBound(0.0, lon + 180.0, 360.0);
+
+    QString result {6, QChar::Space};
+    result[0] = alphabet.at(int(lon/20));
+    result[1] = alphabet.at(int(lat/10));
+    result[2] = numbers.at(int((lon/2))%10);
+    result[3] = numbers.at(int(lat)%10);
+    double lat_remainder = (lat - int(lat)) * 60;
+    double lon_remainder = ((lon) - int(lon/2)*2) * 60;
+    result[4] = alphabet.at(int(lon_remainder/5));
+    result[5] = alphabet.at(int(lat_remainder/2.5));
+    return result;
+}
+
+QGeoCoordinate toGeoCoordinate(QString gridsquare)
+{
+    if (gridsquare.isEmpty())
+        return {};
+
+    const auto bytes = gridsquare.toUpper().toUtf8();
+    double lat = (bytes[1] - 'A') * 10 + (bytes[3] - '0')     + (bytes[5] - 'A' + 0.5) * 2.5 / 60.0 - 90.0;
+    double lon = (bytes[0] - 'A') * 20 + (bytes[2] - '0') * 2 + (bytes[4] - 'A' + 0.5) * 5.0 / 60.0 - 180.0;
+    return { lat, lon };
+}
+
+}  // namespace maidenhead

--- a/src/maidenhead.h
+++ b/src/maidenhead.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef CLO_MAIDENHEAD_H
+#define CLO_MAIDENHEAD_H
+
+#include <QtGlobal>
+
+QT_BEGIN_NAMESPACE
+class QGeoCoordinate;
+class QString;
+QT_END_NAMESPACE
+
+namespace maidenhead {
+    /// Produce locator string from geo coordinate.
+    QString fromLatLon(const QGeoCoordinate& coord);
+
+    /// Produce locator string from latitude and longitude.
+    QString fromLatLon(double lat, double lon);
+
+    /// Produce representative geo coordinate from locator string.
+    QGeoCoordinate toGeoCoordinate(QString gridsquare);
+}
+
+#endif // CLO_MAIDENHEAD_H

--- a/src/repeatermodel.cpp
+++ b/src/repeatermodel.cpp
@@ -2,6 +2,9 @@
 
 #include <QCoreApplication>
 
+#include "maidenhead.h"
+
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0) && QT_CONFIG(permissions)
 #  define CLO_HAVE_QPERMISSION
 #  include <QPermissions>
@@ -107,8 +110,8 @@ QHash<int, QByteArray> rbManager::roleNames() const
 void rbManager::positionUpdated(const QGeoPositionInfo &info)
 {
     qDebug() << "Position updated: " << info;
-    coord = info.coordinate();
-    calculateMaidenhead(coord.latitude(), coord.longitude());
+    locator = maidenhead::fromLatLon(info.coordinate());
+    emit locatorDone(locator);
     getRepeaters();
 }
 
@@ -140,26 +143,6 @@ double rbManager::distance(double rLat, double rLon)
 {
     QGeoCoordinate repeater(rLat,rLon);
     return repeater.distanceTo(coord)/1000.0;
-}
-
-void rbManager::calculateMaidenhead(double lat, double lon)
-{
-    QString alphabet = "ABCDEFGHIJKLMNOPQRSTUVWX";
-
-    lat = lat + 90.0;
-    lon = lon + 180.0;
-
-    QString grid_lat_sq = alphabet.at(int(lat/10));
-    QString grid_lon_sq = alphabet.at(int(lon/20));
-    QString grid_lat_field = QString::number(int(lat)%10);
-    QString grid_lon_field = QString::number(int((lon/2))%10);
-    double lat_remainder = (lat - int(lat)) * 60;
-    double lon_remainder = ((lon) - int(lon/2)*2) * 60;
-    QString grid_lat_subsq = alphabet.at(int(lat_remainder/2.5));
-    QString grid_lon_subsq = alphabet.at(int(lon_remainder/5));
-
-    locator = grid_lon_sq + grid_lat_sq + grid_lon_field + grid_lat_field + grid_lon_subsq + grid_lat_subsq;
-    emit locatorDone(locator);
 }
 
 QString rbManager::getLocator()

--- a/src/repeatermodel.h
+++ b/src/repeatermodel.h
@@ -31,8 +31,6 @@ class rbManager : public QAbstractListModel
 {
     Q_OBJECT
 
-    friend class MaidenheadTest;
-
     enum Role {
         call = Qt::UserRole,
         lati,
@@ -70,7 +68,6 @@ private:
     bool initialized;
     bool filter(double rLat, double rLon, double radius);
     double distance(double rLat, double rLon);
-    void calculateMaidenhead(double lat, double lon);
     void init();
 
     QList<relais> database;

--- a/tests/maidenhead_t.cpp
+++ b/tests/maidenhead_t.cpp
@@ -1,26 +1,27 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include <QGeoCoordinate>
 #include <QTest>
 
-#include "repeatermodel.h"
+#include "maidenhead.h"
 
 class MaidenheadTest: public QObject
 {
     Q_OBJECT
 
-    rbManager repeaters;
-
 private slots:
-    void testCalculateMaidenhead()
+    void testFromLatLon()
     {
         // Avoiding data-driven test for speed and error output
-        auto calculateMaidenhead = [this](double lat, double lon) -> QString {
-            repeaters.calculateMaidenhead(lat, lon);
-            return repeaters.getLocator();
-        };
-        QCOMPARE(calculateMaidenhead(49.99, 20.01), "KN09AX");
-        QCOMPARE(calculateMaidenhead(50.01, 19.99), "JO90XA");
-        QCOMPARE(calculateMaidenhead(-33.93, 18.39), "JF96EB");
+        QCOMPARE(maidenhead::fromLatLon(49.99, 20.01), "KN09AX");
+        QCOMPARE(maidenhead::fromLatLon(50.01, 19.99), "JO90XA");
+        QCOMPARE(maidenhead::fromLatLon(-33.93, 18.39), "JF96EB");
+    }
+
+    void testRoundTrip()
+    {
+        QCOMPARE(maidenhead::fromLatLon(maidenhead::toGeoCoordinate("KN09AX")), "KN09AX");
+        QCOMPARE(maidenhead::fromLatLon(maidenhead::toGeoCoordinate("JO90XA")), "JO90XA");
     }
 };
 


### PR DESCRIPTION
Remove from `repeatermodel/rbManager`.
Add conversion to representative geo coordinate and round-trip test.

(Adapted from https://github.com/myzinsky/cloudLogOffline/pull/109.)